### PR TITLE
Linux bringup

### DIFF
--- a/npu/runtime/apprunner.py
+++ b/npu/runtime/apprunner.py
@@ -123,11 +123,7 @@ Try shutting down/restarting all other jupyter notebooks and try again.""")
         else creates a new device.
         """
         
-        try:  
-            objects = gc.get_objects()  
-        except Exception as e:  
-            print(f"Encountered an exception during gc.get_objects(): {e}")  
-            objects = []
+        objects = gc.get_objects()
 
         for obj in objects:
             try:

--- a/npu/runtime/apprunner.py
+++ b/npu/runtime/apprunner.py
@@ -122,10 +122,21 @@ Try shutting down/restarting all other jupyter notebooks and try again.""")
         if there is gets the device from previously allocated AppRunner or
         else creates a new device.
         """
-        for obj in gc.get_objects():
-            if isinstance(obj, type(self)) and (obj != self):
-                if obj.device is not None:
-                    return obj.device
+        
+        try:  
+            objects = gc.get_objects()  
+        except Exception as e:  
+            print(f"Encountered an exception during gc.get_objects(): {e}")  
+            objects = []
+
+        for obj in objects:
+            try:
+                if isinstance(obj, type(self)) and (obj != self):
+                    if obj.device is not None:
+                        return obj.device
+            except Exception as e:
+                print(f"Encountered an exception during isinstance check: {e}")
+                continue
         return ipr.device(0)
 
     def _process_handoff_metadata(self, xclbin_name:str, handoff:Optional[str]=None)->None: 


### PR DESCRIPTION
I was running into issues with `gc.get_objects()` when using apprunner with other things loaded in the same section e.g. OpenAI chat client:

```
Cell In[121], line 1
----> 1 app = AppRunner('SingleKernelApp.xclbin')

File [~/projects/ml_env/lib/python3.12/site-packages/npu/runtime/apprunner.py:99](http://192.168.0.10:8888/home/shawn/projects/ml_env/lib/python3.12/site-packages/npu/runtime/apprunner.py#line=98), in AppRunner.__init__(self, xclbin_name, fw_sequence, handoff)
     96 # Run the script to allow this unsigned firmware xclbin to run
     98 self.kernel_params = self._get_kernel_info(xclbin_name)
---> 99 self.device =  self._get_device()
    101 try:
    102     self.device.register_xclbin(xclbin)

File [~/projects/ml_env/lib/python3.12/site-packages/npu/runtime/apprunner.py:126](http://192.168.0.10:8888/home/shawn/projects/ml_env/lib/python3.12/site-packages/npu/runtime/apprunner.py#line=125), in AppRunner._get_device(self)
    121 """ Checks to see if there is already an AppRunner that exists. 
    122 if there is gets the device from previously allocated AppRunner or
    123 else creates a new device.
    124 """
    125 for obj in gc.get_objects():
--> 126     if isinstance(obj, type(self)) and (obj != self):
    127         if obj.device is not None:
    128             return obj.device

File [~/projects/ml_env/lib/python3.12/site-packages/openai/_utils/_proxy.py:49](http://192.168.0.10:8888/home/shawn/projects/ml_env/lib/python3.12/site-packages/openai/_utils/_proxy.py#line=48), in LazyProxy.__class__(self)
     46 @property  # type: ignore
     47 @override
     48 def __class__(self) -> type:  # pyright: ignore
---> 49     proxied = self.__get_proxied__()
     50     if issubclass(type(proxied), LazyProxy):
     51         return type(proxied)
...
...
...
File [~/projects/ml_env/lib/python3.12/site-packages/openai/_client.py:104](http://192.168.0.10:8888/home/shawn/projects/ml_env/lib/python3.12/site-packages/openai/_client.py#line=103), in OpenAI.__init__(self, api_key, organization, project, base_url, timeout, max_retries, default_headers, default_query, http_client, _strict_response_validation)
    102     api_key = os.environ.get("OPENAI_API_KEY")
    103 if api_key is None:
--> 104     raise OpenAIError(
    105         "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
    106     )
    107 self.api_key = api_key
    109 if organization is None:

OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```

This PR should solve that issue for this an similar cases.